### PR TITLE
Add Oric console and RAOricutron emulator entries

### DIFF
--- a/RA_Interface.h
+++ b/RA_Interface.h
@@ -33,6 +33,7 @@ enum EmulatorID
     RA_Meka = 8,
     RA_QUASI88 = 9,
     RA_AppleWin = 10,
+    RA_Oricutron = 11,
 
     NumEmulatorIDs,
     UnknownEmulator = NumEmulatorIDs

--- a/RA_Interface.h
+++ b/RA_Interface.h
@@ -73,7 +73,7 @@ enum ConsoleID
     MSX = 29,
     C64 = 30,
     ZX81 = 31,
-    // unused32 = 32,
+    Oric = 32,
     SG1000 = 33,
     VIC20 = 34,
     Amiga = 35,


### PR DESCRIPTION
Reopening from https://github.com/RetroAchievements/RAIntegration/pull/288 since the overlay no longer flickers with SDL.