### PR TITLE
Add RASCV emulator entry

### DIFF
--- a/RA_Interface.h
+++ b/RA_Interface.h
@@ -35,6 +35,7 @@ enum EmulatorID
     RA_AppleWin = 10,
     RA_Oricutron = 11,
     RA_MelonDS = 12,
+    RA_SCV = 13,
 
     NumEmulatorIDs,
     UnknownEmulator = NumEmulatorIDs


### PR DESCRIPTION
At https://github.com/rzumer/RASCV.

Emulator does not support pausing or frame advance. The overlay is displayed with Pause and exited with Escape, other controls (directional, confirm/cancel) are controlled with the configured joystick input. Most games are paused with Space (possibly a hardcoded pause switch?), but since it's not an emulator pause feature the overlay won't control it.

ROM hashing is headerless, and memory map is full CPU space, even though in practice only about a fourth of it is useful it's simpler that way.