### PR TITLE
Update ConsoleID enum

### DIFF
--- a/RA_Consoles.h
+++ b/RA_Consoles.h
@@ -71,6 +71,10 @@ enum ConsoleID
     SharpX1 = 64,
     Tic80 = 65,
     ThomsonTO8 = 66,
+	PC6000 = 67,
+	Pico = 68,
+	MegaDuck = 69,
+	Zeebo = 70,
 
     NumConsoleIDs
 };

--- a/RA_Consoles.h
+++ b/RA_Consoles.h
@@ -71,10 +71,10 @@ enum ConsoleID
     SharpX1 = 64,
     Tic80 = 65,
     ThomsonTO8 = 66,
-	PC6000 = 67,
-	Pico = 68,
-	MegaDuck = 69,
-	Zeebo = 70,
+    PC6000 = 67,
+    Pico = 68,
+    MegaDuck = 69,
+    Zeebo = 70,
 
     NumConsoleIDs
 };


### PR DESCRIPTION
Assigning console IDs to PC-6000 series, Sega Pico, Mega Duck, and Zeebo..