### PR TITLE
Update RA_Consoles.h

### DIFF
--- a/RA_Consoles.h
+++ b/RA_Consoles.h
@@ -77,6 +77,10 @@ enum ConsoleID
     Zeebo = 70,
     Arduboy = 71,
     WASM4 = 72,
+    Arcadia2001 = 73,
+    IntertonVC4000 = 74,
+    ElektorTVGamesComputer = 75,
+    PCEngineCD = 76,
 
     NumConsoleIDs
 };


### PR DESCRIPTION
Adds console IDs for Arcadia 2001 (73), Interton VC 4000  (74), Elektor TV Games Computer (75), and PC Engine CD (76).