### PR TITLE
Update RA_Consoles.h

### DIFF
--- a/RA_Consoles.h
+++ b/RA_Consoles.h
@@ -83,6 +83,8 @@ enum ConsoleID
     PCEngineCD = 76,
     JaguarCD = 77,
     DSi = 78,
+    TI83 = 79,
+    Uzebox = 80,
 
     NumConsoleIDs
 };


### PR DESCRIPTION
Adds console IDs for TI-83 (79) and Uzebox (80).