### PR TITLE
ensure widened string is properly null terminated

### DIFF
--- a/RA_Interface.cpp
+++ b/RA_Interface.cpp
@@ -355,6 +355,8 @@ static BOOL DoBlockingHttpCall(const char* sHostUrl, const char* sRequestedPage,
         mbstowcs_s(&nTemp, wBuffer, sizeof(wBuffer) / sizeof(wBuffer[0]), sHostName, nHostnameLen);
 #else
         nTemp = mbstowcs(wBuffer, sHostName, nHostnameLen);
+        if (nTemp > 0)
+            wBuffer[nTemp] = '\0';
 #endif
 
         if (nTemp > 0)
@@ -373,6 +375,8 @@ static BOOL DoBlockingHttpCall(const char* sHostUrl, const char* sRequestedPage,
             mbstowcs_s(&nTemp, wBuffer, sizeof(wBuffer) / sizeof(wBuffer[0]), sRequestedPage, strlen(sRequestedPage) + 1);
 #else
             nTemp = mbstowcs(wBuffer, sRequestedPage, strlen(sRequestedPage) + 1);
+            if (nTemp > 0)
+                wBuffer[nTemp] = '\0';
 #endif
 
             hRequest = WinHttpOpenRequest(hConnect,


### PR DESCRIPTION
According to the [documentation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/mbstowcs-mbstowcs-l?view=msvc-170#return-value), `mbstowcs` doesn't null terminate the output string, so there's a non-zero chance of the resulting string being malformed.

> If the return value is count, the wide-character string isn't null-terminated.

I believe this is causing the intermittent errors logging in through WinArcadia: https://discord.com/channels/310192285306454017/962817919698501702/1215470789105815713

We'd still need WinArcadia to uptake these changes to get the fix.

This isn't a problem for applications built in Visual Studio because `mbstowcs_s` [does null terminate](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/mbstowcs-s-mbstowcs-s-l?view=msvc-170#remarks).

> The destination string is always null-terminated (even if there's an error).