### PR TITLE
download -x64 dll to -x64 file

### DIFF
--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -101,6 +101,10 @@ if not "%ACTIVE_BRANCH%" == "master" (
     )
 )
 
+set VERSION_FULL=%VERSION_TAG%
+if not "%VERSION_REVISION%" == "0" set VERSION_FULL=%VERSION_FULL%.%VERSION_REVISION%
+if not "%ACTIVE_BRANCH%" == "master" set VERSION_FULL=%VERSION_FULL%-%ACTIVE_BRANCH%
+
 rem === Generate a new version file ===
 @echo Branch: %BRANCH_INFO% (%VERSION_TAG%)
 
@@ -111,6 +115,7 @@ echo #define %DEFINE_PREFIX%_VERSION_MINOR %VERSION_MINOR% >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_PATCH %VERSION_PATCH% >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_REVISION %VERSION_REVISION% >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_PRODUCT "%VERSION_PRODUCT%" >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_FULL "%VERSION_FULL%" >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_COMMIT_HASH "%FULLHASH%" >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_COMMIT_HASH_SHORT "%FULLHASH:~0,8%" >> Temp.txt
 

--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -20,6 +20,10 @@ rem === Get the current branch ===
 git rev-parse --abbrev-ref HEAD > Temp.txt
 set /p ACTIVE_BRANCH=<Temp.txt
 
+rem === Get the current commit hash ===
+git rev-parse HEAD > Temp.txt
+set /p FULLHASH=<Temp.txt
+
 rem === Get the most recent tag matching our prefix ===
 git describe --tags --match "%GIT_TAG%.*" > Temp.txt 2>&1
 set /p ACTIVE_TAG=<Temp.txt
@@ -101,6 +105,8 @@ echo #define %DEFINE_PREFIX%_VERSION_MINOR %VERSION_MINOR% >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_PATCH %VERSION_PATCH% >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_REVISION %VERSION_REVISION% >> Temp.txt
 echo #define %DEFINE_PREFIX%_VERSION_PRODUCT "%VERSION_PRODUCT%" >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_COMMIT_HASH "%FULLHASH%" >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_COMMIT_HASH_SHORT "%FULLHASH:~0,8%" >> Temp.txt
 
 rem === Update the existing file only if the new file differs (fc requires backslashes) ===
 set TARGET_FILE=%TARGET_FILE:/=\%

--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -56,6 +56,9 @@ set VERSION_REVISION=0
 
 set BRANCH_INFO=%ACTIVE_BRANCH%
 
+rem === Treat develop branch like master branch for dirty detection ===
+if "%ACTIVE_BRANCH%" == "develop" set ACTIVE_BRANCH=master
+
 rem === Build the product version. If on a branch, include the branch name ===
 set VERSION_PRODUCT=%VERSION_TAG%
 

--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -25,9 +25,15 @@ git rev-parse HEAD > Temp.txt
 set /p FULLHASH=<Temp.txt
 
 rem === Get the most recent tag matching our prefix ===
-git describe --tags --match "%GIT_TAG%.*" > Temp.txt 2>&1
+if "%GIT_TAG%" == """" (
+    git describe --tags > Temp.txt 2>&1
+) else (
+    git describe --tags --match "%GIT_TAG%.*" > Temp.txt 2>&1
+)
 set /p ACTIVE_TAG=<Temp.txt
 if "%ACTIVE_TAG:~0,5%" == "fatal" goto no_tag
+
+if "%GIT_TAG%" == """" set ACTIVE_TAG=X.%ACTIVE_TAG%
 
 rem === Get the number of commits since the tag and remove the hash PREFIX-COMMITS-HASH ===
 for /f "tokens=1,2 delims=-" %%a in ("%ACTIVE_TAG%") do set ACTIVE_TAG=%%a&set VERSION_REVISION=%%b

--- a/MakeBuildVer.sh
+++ b/MakeBuildVer.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+TARGET_FILE=$1
+GIT_TAG=$2
+DEFINE_PREFIX=$3
+
+if [[ -z "$TARGET_FILE" || -z "$DEFINE_PREFIX" ]]; then
+    echo Usage: MakeBuildVer.sh [TargetFile] [GitTag] [DefinePrefix]
+    exit 1
+fi
+
+# === Get the current branch ===
+ACTIVE_BRANCH=`git rev-parse --abbrev-ref HEAD`
+FULLHASH=`git rev-parse HEAD`
+
+# === Get the most recent tag matching our prefix ===
+if [ -z "$GIT_TAG" ]; then
+    ACTIVE_TAG=`git describe --tags 2>&1`
+else
+    ACTIVE_TAG=`git describe --tags --match "$GIT_TAG.*" 2>&1`
+fi
+
+if [[ "${ACTIVE_TAG:0:5}" == "fatal" ]]; then
+    VERSION_TAG=NO TAG
+    VERSION_MAJOR=0
+    VERSION_MINOR=0
+    VERSION_PATCH=0
+    VERSION_REVISION=0
+else
+    if [ -z "$GIT_TAG" ]; then
+        ACTIVE_TAG="X.$ACTIVE_TAG"
+    fi
+
+    # === Get the number of commits since the tag and remove the hash PREFIX-COMMITS-HASH ===
+    VERSION_REVISION=`echo "$ACTIVE_TAG" | cut -d '-' -f2`
+    if [ -z "$VERSION_REVISION" ]; then
+        VERSION_REVISION=0
+    fi
+
+    # === Extract the major/minor/patch version from the tag (append 0s if necessary) ===
+    ACTIVE_TAG=`echo "$ACTIVE_TAG" | cut -d '-' -f1`
+    IFS="." read -r IGNORE VERSION_MAJOR VERSION_MINOR VERSION_PATCH IGNORE <<< "$ACTIVE_TAG.0.0"
+    VERSION_TAG=`echo "$ACTIVE_TAG" | cut -d '.' -f2-`
+fi
+
+BRANCH_INFO=$ACTIVE_BRANCH
+
+# === Treat develop branch like master branch for dirty detection ===
+if [[ "$ACTIVE_BRANCH" == "develop" ]]; then
+    ACTIVE_BRANCH=master
+fi
+
+# === Build the product version. If on a branch, include the branch name ===
+VERSION_PRODUCT=$VERSION_TAG
+
+if [[ "${ACTIVE_BRANCH:0:5}" == "alpha" ]]; then
+    PRERELEASE_VERSION_MINOR=$((VERSION_MINOR+1))
+elif [[ "${ACTIVE_BRANCH:0:4}" == "beta" ]]; then
+    PRERELEASE_VERSION_MINOR=$((VERSION_MINOR+1))
+fi
+
+# === If there are any local modifications, set branch name to "dirty" ===
+if ! git diff --exit-core > /dev/null 2>&1; then
+    BRANCH_INFO="$BRANCH_INFO [modified]"
+    if [[ "$ACTIVE_BRANCH" == "master" ]]; then
+        ACTIVE_BRANCH=dirty
+    fi
+fi
+
+# === If we're on master and there any local commits, set branch name to "dirty" ===
+if [[ "$ACTIVE_BRANCH" == "master" ]]; then
+    # === Get the upstream branch ===
+    UPSTREAM_BRANCH=`git rev-parse --abbrev-ref @{upstream} 2>/dev/null`
+    if [ -z $UPSTREAM_BRANCH ]; then
+        UPSTREAM_BRANCH=origin/master
+    fi
+
+    # === Determine how many local commits exist ===
+    AHEAD_COUNT=`git rev-list --count $UPSTREAM_BRANCH..$ACTIVE_BRANCH`
+    if [[ "$AHEAD_COUNT" != "0" ]]; then
+        VERSION_REVISION=$((VERSION_REVISION-$AHEAD_COUNT))
+        ACTIVE_BRANCH=dirty
+    fi
+fi
+echo "${ACTIVE_BRANCH: -6}"
+
+# === If not on a clean master branch, capture the branch name/dirty state ===
+if [[ "$ACTIVE_BRANCH" != "master" ]]; then
+    if [[ "$PRERELEASE_VERSION_MINOR" != "" ]]; then
+        VERSION_PRODUCT=$VERSION_MAJOR.$PRERELEASE_VERSION_MINOR-$ACTIVE_BRANCH
+    elif [[ "${ACTIVE_BRANCH: -6}" != "-fixes" ]]; then
+        VERSION_PRODUCT=$VERSION_PRODUCT-$ACTIVE_BRANCH
+    fi
+fi
+
+VERSION_FULL=$VERSION_TAG
+if [[ "$VERSION_REVISION" != "0" ]]; then
+    VERSION_FULL=$VERSION_FULL.$VERSION_REVISION
+fi
+if [[ "$ACTIVE_BRANCH" != "master" ]]; then
+    VERSION_FULL=$VERSION_FULL-$ACTIVE_BRANCH
+fi
+
+
+# === Generate a new version file ===
+echo "Branch: $BRANCH_INFO ($VERSION_TAG)"
+
+echo "#define ${DEFINE_PREFIX}_VERSION \"$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH.$VERSION_REVISION\"" > Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_SHORT \"$VERSION_TAG\"" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_MAJOR $VERSION_MAJOR" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_MINOR $VERSION_MINOR" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_PATCH $VERSION_PATCH" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_REVISION $VERSION_REVISION" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_PRODUCT \"$VERSION_PRODUCT\"" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_FULL \"$VERSION_FULL\"" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_COMMIT_HASH \"$FULLHASH\"" >> Temp.txt
+echo "#define ${DEFINE_PREFIX}_VERSION_COMMIT_HASH_SHORT \"${FULLHASH:0:8}\"" >> Temp.txt
+
+# === Update the existing file only if the new file differs (fc requires backslashes) ===
+if [ ! -f "$TARGET_FILE" ]; then
+    # === File doesn't exist ===
+    mv Temp.txt "$TARGET_FILE" > /dev/null
+elif ! cmp -s "$TARGET_FILE" Temp.txt; then
+    # === File has changed ===
+    rm "$TARGET_FILE"
+    mv Temp.txt "$TARGET_FILE" > /dev/null
+else
+    # === File has not changed ===
+    rm Temp.txt
+fi

--- a/RA_Interface.cpp
+++ b/RA_Interface.cpp
@@ -9,6 +9,13 @@
 #define CCONV __cdecl
 #endif
 
+#if defined(_M_X64) || defined(__amd64__)
+ #define RA_X64
+ #define RA_INT_DLL L"RA_Integration-x64.dll"
+#else
+ #define RA_INT_DLL L"RA_Integration.dll"
+#endif
+
 // Initialization
 static const char*  (CCONV* _RA_IntegrationVersion)() = nullptr;
 static const char*  (CCONV* _RA_HostName)() = nullptr;
@@ -534,7 +541,7 @@ static BOOL DoBlockingHttpCallWithRetry(const char* sHostUrl, const char* sReque
 }
 
 #ifndef RA_UTEST
-static std::wstring GetIntegrationPath()
+static std::wstring GetIntegrationPath(const wchar_t* sFilename)
 {
     wchar_t sBuffer[2048];
     DWORD iIndex = GetModuleFileNameW(0, sBuffer, 2048);
@@ -542,9 +549,9 @@ static std::wstring GetIntegrationPath()
         --iIndex;
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400
-    wcscpy_s(&sBuffer[iIndex], sizeof(sBuffer)/sizeof(sBuffer[0]) - iIndex, L"RA_Integration.dll");
+    wcscpy_s(&sBuffer[iIndex], sizeof(sBuffer)/sizeof(sBuffer[0]) - iIndex, sFilename);
 #else
-    wcscpy(&sBuffer[iIndex], L"RA_Integration.dll");
+    wcscpy(&sBuffer[iIndex], sFilename);
 #endif
 
     return std::wstring(sBuffer);
@@ -554,9 +561,14 @@ static std::wstring GetIntegrationPath()
 static void FetchIntegrationFromWeb(char* sLatestVersionUrl, DWORD* pStatusCode)
 {
     DWORD nBytesRead = 0;
-    const wchar_t* sDownloadFilename = L"RA_Integration.download";
-    const wchar_t* sFilename = L"RA_Integration.dll";
-    const wchar_t* sOldFilename = L"RA_Integration.old";
+    const wchar_t* sDownloadFilename = RA_INT_DLL ".download";
+    const wchar_t* sFilename = RA_INT_DLL;
+    const wchar_t* sOldFilename = RA_INT_DLL ".old";
+
+#ifdef RA_X64
+    if (GetFileAttributesW(sFilename) == INVALID_FILE_ATTRIBUTES)
+      sFilename = L"RA_Integration.dll";
+#endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400
     FILE* pf;
@@ -571,9 +583,9 @@ static void FetchIntegrationFromWeb(char* sLatestVersionUrl, DWORD* pStatusCode)
         wchar_t sErrBuffer[2048];
         _wcserror_s(sErrBuffer, sizeof(sErrBuffer) / sizeof(sErrBuffer[0]), nErr);
 
-        std::wstring sErrMsg = std::wstring(L"Unable to write ") + sOldFilename + L"\n" + sErrBuffer;
+        std::wstring sErrMsg = std::wstring(L"Unable to write ") + sDownloadFilename + L"\n" + sErrBuffer;
 #else
-        std::wstring sErrMsg = std::wstring(L"Unable to write ") + sOldFilename + L"\n" + _wcserror(errno);
+        std::wstring sErrMsg = std::wstring(L"Unable to write ") + sDownloadFilename + L"\n" + _wcserror(errno);
 #endif
 
         MessageBoxW(nullptr, sErrMsg.c_str(), L"Error", MB_OK | MB_ICONERROR);
@@ -615,7 +627,7 @@ static void FetchIntegrationFromWeb(char* sLatestVersionUrl, DWORD* pStatusCode)
             MessageBoxW(nullptr, L"Could not rename old dll", L"Error", MB_OK | MB_ICONERROR);
         }
         // rename the download to be the dll
-        else if (!MoveFileW(sDownloadFilename, sFilename))
+        else if (!MoveFileW(sDownloadFilename, RA_INT_DLL))
         {
             MessageBoxW(nullptr, L"Could not rename new dll", L"Error", MB_OK | MB_ICONERROR);
         }
@@ -653,9 +665,15 @@ static const char* CCONV _RA_InstallIntegration()
 {
     SetErrorMode(0);
 
-    std::wstring sIntegrationPath = GetIntegrationPath();
+    std::wstring sIntegrationPath = GetIntegrationPath(RA_INT_DLL);
 
     DWORD dwAttrib = GetFileAttributesW(sIntegrationPath.c_str());
+#ifdef RA_X64
+    if (dwAttrib == INVALID_FILE_ATTRIBUTES) {
+        sIntegrationPath = GetIntegrationPath(L"RA_Integration.dll");
+        dwAttrib = GetFileAttributesW(sIntegrationPath.c_str());
+    }
+#endif
     if (dwAttrib == INVALID_FILE_ATTRIBUTES)
         return "0.0";
 
@@ -663,7 +681,23 @@ static const char* CCONV _RA_InstallIntegration()
     if (g_hRADLL == nullptr)
     {
         char buffer[1024];
-        sprintf_s(buffer, 1024, "Could not load RA_Integration.dll: %d\n%s\n", ::GetLastError(), GetLastErrorAsString().c_str());
+        if (::GetLastError() == ERROR_BAD_EXE_FORMAT)
+        {
+#ifdef RA_X64
+          sprintf_s(buffer, sizeof(buffer), "Could not load RA_Integration-x64.dll (error %d)\nAre you trying to load the 32-bit version?\n", ::GetLastError());
+#else
+          sprintf_s(buffer, sizeof(buffer), "Could not load RA_Integration.dll (error %d)\nAre you trying to load the 64-bit version?\n", ::GetLastError());
+#endif
+        }
+        else
+        {
+#ifdef RA_X64
+            sprintf_s(buffer, sizeof(buffer), "Could not load RA_Integration-x64.dll (error %d)\n%s\n", ::GetLastError(), GetLastErrorAsString().c_str());
+#else
+            sprintf_s(buffer, sizeof(buffer), "Could not load RA_Integration.dll (error %d)\n%s\n", ::GetLastError(), GetLastErrorAsString().c_str());
+#endif
+        }
+
         MessageBoxA(nullptr, buffer, "Warning", MB_OK | MB_ICONWARNING);
 
         return "0.0";
@@ -872,7 +906,7 @@ static void RA_InitCommon(HWND hMainHWND, int nEmulatorID, const char* sClientNa
     GetJsonField(buffer, "LatestVersion", sVersionBuffer, sizeof(sVersionBuffer));
     const unsigned long long nLatestDLLVer = ParseVersion(sVersionBuffer);
 
-#if defined(_M_X64) || defined(__amd64__)
+#ifdef RA_X64
     GetJsonField(buffer, "LatestVersionUrlX64", sLatestVersionUrl, sizeof(sLatestVersionUrl));
 #else
     GetJsonField(buffer, "LatestVersionUrl", sLatestVersionUrl, sizeof(sLatestVersionUrl));


### PR DESCRIPTION
For emulators integrating with RAIntegration.dll, if built for x64, the dll that is downloaded will no longer be renamed to RAIntegration.dll. Instead, it will keep the RAIntegration-x64.dll name. This will make it easier to differentiate from the x86 version of the dll when copying to other emulators using the rc_client integration to load the dll.

For backwards compatibility, the non-x64 name will be checked and used if an -x64 named dll is not present. The next time the dll is downloaded, the name will automatically be changed.

Additionally, adds special handling for the 193 error code, asking the user if they're using the version for the alternate architecture.